### PR TITLE
fix/issue-38-terms-of-use

### DIFF
--- a/src/content/pagesContents/terms-of-use.md
+++ b/src/content/pagesContents/terms-of-use.md
@@ -2,15 +2,11 @@
 title: Terms of use
 ---
 
-The Impresso Datalab is a platform for programmatic data access and annotation services and is developed by the [Impresso project](https://impresso-project.ch) which strives to create meaningful links across historical media collections. The Datalab enables custom analyses of the Impresso corpus and the semantic indexation of external document collections also with the help of models created by the project.
+**Last update:** 8 October 2024
 
-Impresso Terms of Use
+### 1. ABOUT
 
-**Last update:** 30 July 2024
-
-## 1. ABOUT
-
-Welcome to Impresso! These Terms of Use (hereinafter "ToU") describe the general terms and conditions of use for Impresso Services and Data. Please note that you must agree to these ToU before using Impresso Services and Data. Therefore, this ToU document constitutes an agreement between you and the Impresso Project (“we”). By clicking on the click-wrap at the bottom of this document, you agree to be bound by these terms and conditions.
+Welcome to Impresso! These Terms of Use (hereinafter "ToU") describe the general terms and conditions of use for Impresso Services and Data. Please note that you must agree to these ToU before using Impresso Services and Data. Therefore, this ToU document constitutes an agreement between you and the Impresso Project ("we"). By clicking on the click-wrap at the bottom of this document, you agree to be bound by these terms and conditions.
 
 These ToU define the terms and conditions under which you (hereinafter "User") may use the following Services and Data:
 
@@ -22,69 +18,62 @@ These ToU define the terms and conditions under which you (hereinafter "User") m
 
 - All Data as defined in Section 3 below and accessible through the Interface, the API and the Annotation Services;
 
-The Interface, the API and the Annotation Services are hereinafter collectively referred to as “Services”.
+The Interface, the API and the Annotation Services are hereinafter collectively referred to as "Services".
 
 The applicable ToU are those that are accessible online on the Interface at <https://impresso-project.ch/app/terms-of-use> on the day that the User uses the Services and the Data. The Impresso Project reserves the right to modify these ToU at any time and asks the User to review the ToU regularly. Users are regularly prompted to do so when accessing the Services. The date of the last update of the ToU is indicated on the first line of this document.
 
 Please also note the Impresso [Privacy Notice](https://docs.google.com/document/d/1-ztNKgc_c-ZGz3p0ftJKcmJ6h4tu2wn11a0EC2nHPEk/edit#heading=h.oxurcm2w6itn), which is not part of this agreement.
 
-## 2. THE IMPRESSO PROJECT
+### 2. THE IMPRESSO PROJECT
 
 Leveraging an unprecedented corpus of newspaper and radio archives, **Impresso – Media Monitoring of the Past** is an interdisciplinary research project that uses machine learning to pursue a paradigm shift in the processing, semantic enrichment, representation, exploration, and study of historical media across modalities, time, languages, and national borders.
 
-The project develops natural language processing techniques to enrich media archives with semantic annotations and to advance digital history research and methods. Impresso designs, implements and provides access to a Graphical User Interface  and an Application Programming Interface for exploring, visualising and comparing large historical print and audio collections.
+The project develops natural language processing techniques to enrich media archives with semantic annotations and to advance digital history research and methods. Impresso designs, implements and provides access to a Graphical User Interface and an Application Programming Interface for exploring, visualising and comparing large historical print and audio collections.
 
-Impresso is funded by the Swiss National Science Foundation under grant No. CRSII5_213585 and by the Luxembourg National Research Fund under grant No. 17498891.
+Impresso is funded by the Swiss National Science Foundation under grant No. CRSII5\_213585 and by the Luxembourg National Research Fund under grant No. 17498891.
 
-## 3. DATA ACCESSIBLE VIA THE IMPRESSO INTERFACE AND API.
+### 3. DATA ACCESSIBLE VIA THE IMPRESSO INTERFACE AND API.
 
-Three types of data are available through the Interface and API, namely **Media Archives**, **Collection Metadata** and **Semantic Enrichments**  (hereinafter collectively referred to as “Data”).
+Three types of data are available through the Interface and API, namely **Media Archives**, **Collection Metadata** and **Semantic Enrichments** (hereinafter collectively referred to as "Data").
 
-### 3.1 Media Archives.
+**3.1 Media Archives.**
 
 Impresso receives Media Archive collections from partner cultural heritage institutions across Europe. Media Archive collections form the Impresso Corpus and correspond to:
 
 - **Print Media Archives**, i.e., **digitised collections of newspapers, radio magazines and radio tapescripts**, composed of the following:
-
   - Facsimiles of periodical pages;
-
   - Transcripts, i.e. the output of Optical Character Recognition (OCR);
-
   - Images (i.e. illustrations, drawings, photographs) appearing on facsimiles alongside the text.
 
 - **Audio Media Archives,** i.e. **digitised collections of radio broadcasts**, composed of the following:
-
   - Audio records of the program;
-
   - Transcripts, i.e. the output of Automatic Speech Recognition (ASR).
 
-Moreover, we define a Content Item \*\*\*\*as the smallest text unit of editorial content in a newspaper or radio collection, i.e. an article in the case of newspapers, or a radio show or episode in the case of radio programs.
+Moreover, we define a *Content Item* as the smallest text unit of editorial content in a newspaper or radio collection, i.e. an article in the case of newspapers, or a radio show or episode in the case of radio programs.
 
-### 3.2 Metadata.
+**3.2 Metadata.**
 
-Metadata (hereinafter “Metadata”) corresponds to contextual information about the media archive collections and includes descriptive metadata (e.g. title, dates, place of publication), structural metadata (e.g. issue, page, content item identifiers), and administrative metadata (file timestamps, file creator, preservation information).
+Metadata (hereinafter "Metadata") corresponds to contextual information about the media archive collections and includes descriptive metadata (e.g. title, dates, place of publication), structural metadata (e.g. issue, page, content item identifiers), and administrative metadata (file timestamps, file creator, preservation information).
 
-### 3.3. Semantic Enrichments.
+**3.3. Semantic Enrichments.**
 
-Semantic Enrichments \*\*\*\*correspond to various types of structured information and computational representations of Media Archives extracted or computed from the Impresso Corpus by the Impresso Project. Semantic Enrichments include, for example, embeddings of words, sentences, entities and images, OCR quality assessment, n-gram statistics, named entity mentions and entities, Content Item classes, topics and topics assignments on Content Items, and text re-use clusters and passages.
+Semantic Enrichments correspond to various types of structured information and computational representations of Media Archives extracted or computed from the Impresso Corpus by the Impresso Project. Semantic Enrichments include, for example, embeddings of words, sentences, entities and images, OCR quality assessment, n-gram statistics, named entity mentions and entities, Content Item classes, topics and topics assignments on Content Items, and text re-use clusters and passages.
 
 It is specified that Media Archives, Metadata and Semantic Enrichments are subject to various copyrights and intellectual property rights held by Impresso Partners and Impresso Project, and that Users, in the course of their authorised access, accept responsibility for the appropriate handling and management of these Data in accordance with these ToU.
 
-## 4. ACCESS TO DATA AND POSSIBLE ACTIONS THROUGH THE INTERFACE AND THE API
+### 4. ACCESS TO DATA AND POSSIBLE ACTIONS THROUGH THE INTERFACE AND THE API
 
-There are two types of Actions possible on the Data through the Interface and API:
-
-- Explore: This includes searching, browsing, exploring, visualising, and comparing Media Archives, Metadata, and Semantic Enrichments.
-
-- Get: This allows for the export of certain Media Archives, Metadata, and Semantic Enrichments.
+There are two types of Actions possible on the Data through the Interface and API:     
+- **Explore**: This includes searching, browsing, exploring, visualising, and comparing Media Archives, Metadata, and Semantic Enrichments.
+- **Get**: This allows for the export of certain Media Archives, Metadata, and Semantic Enrichments.
 
 Access to Data and the permitted Actions through the Interface and API depend on the copyright status of the Media Archives and on the User's status.
 
 These ToU apply to all Users irrespective of their status, and to all Data irrespective of the method of retrieval (whether through Explore or Get actions).
 
-## 5. CONDITIONS FOR OPENING AN IMPRESSO USER ACCOUNT
+### 5. CONDITIONS FOR OPENING AN IMPRESSO USER ACCOUNT
 
-A User may register an Impresso User Account \*\*\*\*to access more Data and Services. This account is assigned individually and requires an email address and password for authentication.
+A User may register an Impresso User Account to access more Data and Services. This account is assigned individually and requires an email address and password for authentication.
 
 To open an Impresso Account, a User must complete the online registration form by providing his/her first and last name(s), email address, academic affiliation if any, and a brief description of the intended research. Once the registration has been validated by the Impresso Project and/or the Cultural Heritage Institution and the User has accepted the ToU, a confirmation email will be sent inviting the User to activate his/her interface or API account. Once the account has been activated, the User will receive a password that will allow him/her to log into the GUI and/or request a time-limited API token.
 
@@ -94,86 +83,89 @@ In the event that the User uses his/her account, login details or the Data and c
 
 The User's passwords and API tokens are personal and the User must not disclose them to any third party.
 
-## 6. MEDIA ARCHIVE COPYRIGHTS DOMAINS
+### 6. MEDIA ARCHIVE COPYRIGHTS DOMAINS
 
 There are two Media Archive Copyright Domains:
 
 1. **Public Domain**: Media Archive that are ineligible for copyright protection or whose copyright has expired and is therefore freely available for anyone to use without restriction.
 
-2. **Protected Domain**: Media Archive that are under copyright \*\*\*\*but are accessible and usable for personal use or for research purposes or for educational purposes.
+2. **Protected Domain**: Media Archive that are under copyright but are accessible and usable for personal use or for research purposes or for educational purposes.
 
-Access to Media Archive within the Protected Domain may be conditioned according to academic affiliation and partner cultural heritage institution, as explained on this information page: LINK.
+Access to Media Archive within the Protected Domain may be conditioned according to academic affiliation and partner cultural heritage institution, as explained on this information page: LINK-TO-ADD.
 
-## 7. PERMITTED USE OF THE DATA
+### 7. PERMITTED USE OF THE DATA
 
-### 7.1 Media Archives\*\* accessible via the Impresso Interface and API can be used under the following conditions:
+**7.1 Media Archives** 
 
-- Media Archives from \***\*the **Public Domain:\*\* No restrictions apply to the usage of such Media Archives. Within the Impresso Interface and API, Media Archive from the Public Domain are labelled as “Public Domain”.
+Media Archives accessible via the Impresso Interface and API can be used under the following conditions:
+
+- Media Archives from the **Public Domain:** No restrictions apply to the usage of such Media Archives. Within the Impresso Interface and API, Media Archive from the Public Domain are labelled as "Public Domain".
 
 - Media Archives from the **Protected Domain** may be used for research purposes ("Research Use" as defined below), and, _when specified_, for educational purposes ("Educational Use") and personal purposes ("Personal Use").
 
-Within the Impresso Interface and API, Protected Domain Media Archives are labelled as “Protected - \[Permitted Use]” where \[Permitted Use] corresponds to “Research Use”, “Educational Use”, “Personal Use”, or a combination thereof.
+Within the Impresso Interface and API, Protected Domain Media Archives are labelled as "Protected - \[Permitted Use]" where \[Permitted Use] corresponds to "Research Use", "Educational Use", "Personal Use", or a combination thereof.
 
-**Research Use** includes the following permissions:
+- **Research Use** includes the following permissions:
 
-- Users are permitted to use Media Archives for academic research activities, as long as they do not fall within the unauthorised uses listed in Section 8. Users have the right to save or print digital documents.
+	- Users are permitted to use Media Archives for academic research activities, as long as they do not fall within the unauthorised uses listed in Section 8. Users have the right to save or print digital documents.
+	
+	- Users may cite digital documents in scientific publications and other dissemination activities (e.g. scientific presentations, blogs or websites, social media).
 
-- Users may cite digital documents in scientific publications and other dissemination activities (e.g. scientific presentations, blogs or websites, social media).
+- **Educational Use** includes the same permission of Research use, with the addition that Media Archives may be used for educational purposes.
 
-**Educational Use** includes the same permission of Research use, with the addition that Media Archives may be used for educational purposes.
-
-**Personal Use** includes private, non-commercial use, performed by an individual  and unrelated to academic research activities or educational use.
+- **Personal Use** includes private, non-commercial use, performed by an individual and unrelated to academic research activities or educational use.
 
 **Any other use of the Protected Domain Media Archives requires permission from the copyright holder(s).**
 
 The Media Archive Copyright Domain and permitted use of Media Archive are indicated at the level of Data elements. This information is available in various views within the Interface and in the data export format.
 
-**It is the User’s responsibility to verify the data domain and Ppermitted Uuse of Data Elements before any usage.** In case of doubt, the User must treat the Data elements(s) as if they belong to the Protected Domain and discuss any questions he/she has with a representative of the Impresso project.
+**It is the User’s responsibility to verify the data domain and Permitted Uuse of Data Elements before any usage.** In case of doubt, the User must treat the Data elements(s) as if they belong to the Protected Domain and discuss any questions he/she has with a representative of the Impresso project.
 
-**The User** \*\*must take appropriate safeguards to prevent use, access to, or disclosure of the Media Archives other than permitted by these Terms of Use.
+**The User** **must take appropriate safeguards to prevent use, access to, or disclosure of the Media Archives other than permitted by these Terms of Use.**
 
-### 7.2 Metadata\*\*. Unless otherwise specified, Metadata is licensed under a CC BY 4.0 licence and can be used without restriction.
+**7.2 Metadata**. 
 
-### 7.3 Semantic Enrichments.\*\* Unless otherwise specified, all Semantic Enrichments are available under the CC-BY-SA 4.0 licence.
+Unless otherwise specified, Metadata is licensed under a [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/) licence and can be used without restriction.
+
+**7.3 Semantic Enrichments.** 
+
+Unless otherwise specified, all Semantic Enrichments are available under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/) licence.
 
 For all Data and usages, Users shall respect the best academic and scientific citation practices as specified in Section 9.
 
-## 8. UNAUTHORISED OR LIMITED USE OF THE DATA
+### 8. UNAUTHORISED OR LIMITED USE OF THE DATA
 
 The Impresso Services **are designed to facilitate research and are not intended for mass downloading** of Public or Protected Data. The Impresso Project receives Media Archives from partners who must be consulted directly for certain uses of the data. Users are prohibited from the following actions:
 
-- Mass-downloading any Data, including from the Public Domain. For data dumps, please contact us or visit the project resource web page.
-
+- Mass-downloading any Data, including from the Public Domain. For data dumps, please contact us or visit the project resource web page.    
 - Training or continue training foundational (language) models using Protected Domain Media Archives. If you have this requirement, please contact us or the partner institutions.
+- Redistributing Media Archives;
+- Using Media Archives for commercial purposes;
 
-* Redistributing Media Archives;
-
-* Using Media Archives for commercial purposes;
-
-## 9. CITATION OF DATA.
+### 9. CITATION OF DATA.
 
 Users shall cite digital items in accordance with standard academic and scientific practice and with [Article 25](https://www.admin.ch/opc/en/classified-compilation/19920251/index.html#a25) of the Swiss Federal Act on Copyright and Related Rights. In particular, citations of Media Archive item(s) should always include their archive owner and the Impresso interface URL if they are found and accessed through it.
 
-## 10. PERSONAL DATA
+### 10. PERSONAL DATA
 
-The Impresso project collects personal data from Users in accordance with its **Privacy Notice**, which is accessible at this link: [https://impresso-project.ch/privacy-notice](https://impresso-project.ch/provicy-notice) .
+The Impresso project collects personal data from Users in accordance with its **Privacy Notice**, which is accessible at this link: [https://impresso-project.ch/privacy-notice](https://impresso-project.ch/provicy-notice).
 
-## 11. SIGNATURE.
+### 11. SIGNATURE.
 
 The User's acceptance of the ToU is by a click-wrap in which the User agrees to and accepts the ToU. This acceptance is considered an original signature.
 
-## 12. APPLICABLE LAW.
+### 12. APPLICABLE LAW.
 
 These terms of use are governed by and construed in accordance with the laws of Switzerland. The exclusive place of jurisdiction shall be Lausanne, Switzerland.
 
-## 13. LIABILITY DISCLAIMER.
+### 13. LIABILITY DISCLAIMER.
 
 The Impresso Project makes newspapers available as cultural and historical sources, in the form in which they appeared at the time. Furthermore, any information (media archives, metadata, semantic annotations) on this website is provided as is, without guarantee of completeness or correctness.
 
-The Impresso Project and its associated cultural heritage partners assume no liability for the use of Media Archives, Metadata, and Semantic Enrichments by users or third parties. Users or third parties shall defend and hold harmless Impresso and its partners of any claim addressed by third parties, notably in case of  infringement of intellectual property rights or personality rights arising from the use of such documents.
+The Impresso Project and its associated cultural heritage partners assume no liability for the use of Media Archives, Metadata, and Semantic Enrichments by users or third parties. Users or third parties shall defend and hold harmless Impresso and its partners of any claim addressed by third parties, notably in case of infringement of intellectual property rights or personality rights arising from the use of such documents.
 
-Impresso \_\_is a research project that experiments with new ways of exploring and enriching media archives. The Services and Data may therefore change in-between releases. Users agree not to hold Impresso liable for the deletion or modification of Services and Data provided through the Interface and API.
+Impresso is a research project that experiments with new ways of exploring and enriching media archives. The Services and Data may therefore change in-between releases. Users agree not to hold Impresso liable for the deletion or modification of Services and Data provided through the Interface and API.
 
-## 14. CONTACT.
+### 14. CONTACT.
 
 For any other questions, please contact info \[at] impresso-project \[dot] ch


### PR DESCRIPTION
- Apparently ToU were already recently added but I did some additional corrections
- In particular, I propose to remove the header on the Datalab, for the following reasons
       - ToU are for both datalab and webapp (users are accepting all together) 
       - what is datalab/webapp/services/etc is defined in the ToU first §
       - this document is agreed on by many ppl and we cannot not change / add.
       
