### PR TITLE
updates of the notebooks githubUrl

### DIFF
--- a/src/content/notebooks/impresso-py-connect.mdx
+++ b/src/content/notebooks/impresso-py-connect.mdx
@@ -1,7 +1,7 @@
 ---
 title: Basic interactions with the Impresso python library
 excerpt: This is the first notebook in the Enter Impresso series.
-githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/starter/ST_01_basics.ipynb
+githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/starter/basics_ImpressoAPI.ipynb
 tags:
   - hello-world
 binderUrl: https://mybinder.org/v2/gh/binder-examples/r/master?urlpath=rstudio

--- a/src/content/notebooks/impresso-py-maps.mdx
+++ b/src/content/notebooks/impresso-py-maps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Exploring impresso with maps
-githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/impresso-py/maps_explore.ipynb
+githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/explore-vis/place-entities_map.ipynb
 authors:
   - impresso-team
 sha: c23bb2461d836ab72c1fb6e3bee11de9b0a7dc16

--- a/src/content/notebooks/impresso-py-network.mdx
+++ b/src/content/notebooks/impresso-py-network.mdx
@@ -1,6 +1,6 @@
 ---
 title: Network graph with Impresso Py
-githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/impresso-py/network_graph.ipynb
+githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/explore-vis/entity_network.ipynb
 authors:
   - impresso-team
 sha: c23bb2461d836ab72c1fb6e3bee11de9b0a7dc16

--- a/src/content/notebooks/language-identification-with-impresso-hf.mdx
+++ b/src/content/notebooks/language-identification-with-impresso-hf.mdx
@@ -1,5 +1,5 @@
 ---
-githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/language-identification/language-identification_with_ImpressoHF.ipynb
+githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/annotate/language-identification_ImpressoHF.ipynb
 authors:
   - impresso-team
 title: Language Identification using Floret

--- a/src/content/notebooks/ne-processing-with-impresso-api.mdx
+++ b/src/content/notebooks/ne-processing-with-impresso-api.mdx
@@ -1,5 +1,5 @@
 ---
-githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/entity/NE-processing_with_ImpressoAPI.ipynb
+githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/annotate/NE-processing_ImpressoAPI.ipynb
 authors:
   - impresso-team
 title: Detect Entities and Link them to Wikipedia and Wikidata in a Text through

--- a/src/content/notebooks/ne-processing-with-impresso-hf.mdx
+++ b/src/content/notebooks/ne-processing-with-impresso-hf.mdx
@@ -1,5 +1,5 @@
 ---
-githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/entity/NE-processing_with_ImpressoHF.ipynb
+githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/annotate/NE-processing_ImpressoHF.ipynb
 authors:
   - impresso-team
 excerpt: Trained on the [HIPE

--- a/src/content/notebooks/newsagency-processing-with-impresso-hf.mdx
+++ b/src/content/notebooks/newsagency-processing-with-impresso-hf.mdx
@@ -1,5 +1,5 @@
 ---
-githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/entity/newsagency-processing_with_ImpressoHF.ipynb
+githubUrl: https://github.com/impresso/impresso-datalab-notebooks/blob/main/annotate/newsagency-processing_ImpressoHF.ipynb
 title: News Agencies Recognition and Linking with Impresso BERT models
 excerpt: Impresso BERT-based pipeline, trained on Swiss and Luxembourgish
   newspapers from the Impresso project, identifies and links news agencies in


### PR DESCRIPTION
Change of the `githubUrl` for the notebooks whose folders have changed in the impresso-datalab-notebooks repository:

I did not change any other URLs (e.g. the colab just below) since I am under the understanding it fetched automatically.